### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 Get real-time mortgage rates directly in Claude Desktop with the RateSpot MCP Server.
 
+<a href="https://glama.ai/mcp/servers/@zad0xlik/ratespot-mcp">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zad0xlik/ratespot-mcp/badge" alt="RateSpot Server MCP server" />
+</a>
+
 ## 🚀 Super Simple Installation
 
 ### 🎯 Desktop Extension (DXT) - Easiest Method!


### PR DESCRIPTION
This PR adds a badge for the [RateSpot MCP Server](https://glama.ai/mcp/servers/@zad0xlik/ratespot-mcp) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@zad0xlik/ratespot-mcp">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@zad0xlik/ratespot-mcp/badge" alt="RateSpot Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.